### PR TITLE
explicitly set python io encoding

### DIFF
--- a/salt/reviewer-suggestions/config/etc-init-reviewer-suggestions-server.conf
+++ b/salt/reviewer-suggestions/config/etc-init-reviewer-suggestions-server.conf
@@ -1,6 +1,7 @@
 description "server working on port 8080"
 respawn
 kill timeout 20
+env PYTHONIOENCODING=UTF-8
 setuid {{ pillar.elife.deploy_user.username }}
 chdir {{ pillar.reviewer_suggestions.installation_path }}/server
 exec {{ pillar.reviewer_suggestions.installation_path }}/venv/bin/python server.py


### PR DESCRIPTION
 explicitly set python io encoding to avoid ascii conversion errors when printing to the console