### PR TITLE
avoid dropping schema by dropping schema_version instead

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -8,7 +8,7 @@ base:
         - elife.aws-cli
         - elife.external-volume
         - elife.external-volume-srv
-        # - elife.newrelic-python
+        - elife.newrelic-python
         - peerscout.postgres
         - peerscout
         - peerscout.cron

--- a/salt/peerscout/init.sls
+++ b/salt/peerscout/init.sls
@@ -124,7 +124,7 @@ peerscout-db-clean:
     cmd.run:
         # local psql, no RDS support
         - name: |
-            timeout 30 psql --no-password {{ pillar.peerscout.db.name}} {{ pillar.peerscout.db.username }} -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'
+            timeout 30 psql --no-password {{ pillar.peerscout.db.name}} {{ pillar.peerscout.db.username }} -c 'DROP TABLE IF EXISTS schema_version;'
         - env:
             - PGPASSWORD: {{ pillar.peerscout.db.password }}
         - require:


### PR DESCRIPTION
Dropping the `schema_version` table should cause the current migration script to drop all tables and re-create them. (deleting the rows would have the same effect but would require the that the table exists to not fail)

Perhaps the name is not 100% accurate as that state itself won't actually clean the database.
Another disadvantage of this is also that it would silently not clean the database if say the schema_version table name was changed. But by that time this approach may not exist anymore.